### PR TITLE
Add requirement about attending gatherings

### DIFF
--- a/proposal-membership.md
+++ b/proposal-membership.md
@@ -32,11 +32,12 @@ After the successful bootstrap of the Buttsortium, Founders will essentially bec
 **Criteria (for individuals)**
 1. Pay a monthly membership fee of 10 Euros (which can be paid in advance for up to 12 months)
 2. Be actively vouched for by at least 5 active members (see “Membership Split” for limit cases)
-3. Have physical or legal presence in Europe, or be involved in an active consortium project with at least one member with a physical or legal presence in Europe
-4. If not a member for the last 12 months:
+3. Have attended at least 1 of the last 3 physical gatherings.
+4. Have physical or legal presence in Europe, or be involved in an active consortium project with at least one member with a physical or legal presence in Europe
+5. If not a member for the last 12 months:
     1. Publicly introduced themselves to the existing members (ex: background, motivation, skills, etc.)
     2. Have made recognized contributions to the larger SSB community (ex: tools, artwork, community gardening, volunteering, etc.)
-5. If a member for the last 12 months: 
+6. If a member for the last 12 months: 
     1. Voted in the last annual general assembly
     2. Performed >=10h of recognized volunteering work for the consortium over the last 12 months, beside voting and participation in meetings.
 

--- a/proposal-membership.md
+++ b/proposal-membership.md
@@ -32,14 +32,14 @@ After the successful bootstrap of the Buttsortium, Founders will essentially bec
 **Criteria (for individuals)**
 1. Pay a monthly membership fee of 10 Euros (which can be paid in advance for up to 12 months)
 2. Be actively vouched for by at least 5 active members (see “Membership Split” for limit cases)
-3. Have attended at least 1 of the last 3 physical gatherings.
-4. Have physical or legal presence in Europe, or be involved in an active consortium project with at least one member with a physical or legal presence in Europe
-5. If not a member for the last 12 months:
+3. Have physical or legal presence in Europe, or be involved in an active consortium project with at least one member with a physical or legal presence in Europe
+4. If not a member for the last 12 months:
     1. Publicly introduced themselves to the existing members (ex: background, motivation, skills, etc.)
     2. Have made recognized contributions to the larger SSB community (ex: tools, artwork, community gardening, volunteering, etc.)
-6. If a member for the last 12 months: 
+5. If a member for the last 12 months: 
     1. Voted in the last annual general assembly
     2. Performed >=10h of recognized volunteering work for the consortium over the last 12 months, beside voting and participation in meetings.
+    3. Have attended at least 1 of the last 3 physical gatherings.
 
 If a member fails to maintain their active status by omitting to fulfill some of the criteria above, they become an “Inactive Member” for up to a year, and loose voting rights. An active member will contact them to understand why. The “Inactive Member” can then choose to: (1) fulfill the criteria to become “Active” again, or (2) become a “Past Member”. In the absence of answer, after one year of “Inactive” status, they automatically become “Past Members”. (see “Recognizing Past Members” below)
 


### PR DESCRIPTION
Not voted on yet, but suggested by at least me and @arj03 

It feels a bit weird to not define what a Gathering is. Could someone suddenly host 3 gatherings within a week in their home town and throw everyone else out of membership that way? I feel like it's implied that a gathering happens every 6 months for the "1 out of the last 3" criteria to make sense, maybe we should be explicit about that?