### PR TITLE
Actively ensure rules are current

### DIFF
--- a/proposal-membership.md
+++ b/proposal-membership.md
@@ -39,6 +39,7 @@ After the successful bootstrap of the Buttsortium, Founders will essentially bec
 5. If a member for the last 12 months: 
     1. Voted in the last annual general assembly
     2. Performed >=10h of recognized volunteering work for the consortium over the last 12 months, beside voting and participation in meetings.
+6. Actively ensure that the membership rules reflects the needs of the current members of the consortium
 
 If a member fails to maintain their active status by omitting to fulfill some of the criteria above, they become an “Inactive Member” for up to a year, and loose voting rights. An active member will contact them to understand why. The “Inactive Member” can then choose to: (1) fulfill the criteria to become “Active” again, or (2) become a “Past Member”. In the absence of answer, after one year of “Inactive” status, they automatically become “Past Members”. (see “Recognizing Past Members” below)
 


### PR DESCRIPTION
I think it is important to add this section, even if it seems a bit self-evident for the current members. In general I think its a good principle and should hopefully make it clear to members coming in after the initial group that they have as much to say about what the rules should be. 