### PR TITLE
Removing sections

### DIFF
--- a/proposal-membership.md
+++ b/proposal-membership.md
@@ -35,10 +35,8 @@ After the successful bootstrap of the Buttsortium, Founders will essentially bec
 3. Have physical or legal presence in Europe, or be involved in an active consortium project with at least one member with a physical or legal presence in Europe
 4. If not a member for the last 12 months:
     1. Publicly introduced themselves to the existing members (ex: background, motivation, skills, etc.)
-    2. Have made recognized contributions to the larger SSB community (ex: tools, artwork, community gardening, volunteering, etc.)
 5. If a member for the last 12 months: 
     1. Voted in the last annual general assembly
-    2. Performed >=10h of recognized volunteering work for the consortium over the last 12 months, beside voting and participation in meetings.
 
 If a member fails to maintain their active status by omitting to fulfill some of the criteria above, they become an “Inactive Member” for up to a year, and loose voting rights. An active member will contact them to understand why. The “Inactive Member” can then choose to: (1) fulfill the criteria to become “Active” again, or (2) become a “Past Member”. In the absence of answer, after one year of “Inactive” status, they automatically become “Past Members”. (see “Recognizing Past Members” below)
 


### PR DESCRIPTION
Removing sections 
due to: 
4(.2) Unnecessary, already integrated part of the vouching for, I believe
5(.2) I don't think we should make a practice of assuming that people can contribute with unpaid work. Also, I don't think we should make it a practice to count and keep tabs on each other.