### PR TITLE
Name Suggestion

### DIFF
--- a/reasoning.md
+++ b/reasoning.md
@@ -1,4 +1,4 @@
-# Reasoning Behind European SSB Collective Rules
+# Reasoning Behind the European SSB Collective's Rules
 
 In order to function as an organization, we need some rules that lay the foundation for how we work. In our experience on Scuttlebutt, we've learned that a central question about making decisions is _who gets to have a say_. On Scuttlebutt, this is very difficult to answer, because "the community" is an amorphos blob, so there is no such thing as a clear consensus.
 

--- a/reasoning.md
+++ b/reasoning.md
@@ -1,4 +1,4 @@
-# Reasoning Behind The Peach Consortiums Rules
+# Reasoning Behind European SSB Collective Rules
 
 In order to function as an organization, we need some rules that lay the foundation for how we work. In our experience on Scuttlebutt, we've learned that a central question about making decisions is _who gets to have a say_. On Scuttlebutt, this is very difficult to answer, because "the community" is an amorphos blob, so there is no such thing as a clear consensus.
 

--- a/reasoning.md
+++ b/reasoning.md
@@ -1,4 +1,4 @@
-# The Reasoning Behind our Rules
+# Reasoning Behind The Peach Consortiums Rules
 
 In order to function as an organization, we need some rules that lay the foundation for how we work. In our experience on Scuttlebutt, we've learned that a central question about making decisions is _who gets to have a say_. On Scuttlebutt, this is very difficult to answer, because "the community" is an amorphos blob, so there is no such thing as a clear consensus.
 


### PR DESCRIPTION
The Peach Consortium
^
This is a name suggestion. I like the sound of it, it's official but cute. I like that it can be written like this The :peach: Consortium and I like that it also enables us to inofficially still be called buttsortium. I like the name buttsortium because it's fun and makes things a bit lighter. I don't want this space to only feel like work (I like playfulness!) while it would simultaniously be great if the name can be a good official face outwards.

I still think we can use the domain name André registered for this year and then switch once the time comes, or set up dual link to a site with two domains.