### PR TITLE
Add a code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -88,3 +88,5 @@ If you are feeling unsafe, you can contact any of the active members of the inte
 Some violations need to be considered and consulted upon with more people or in a more measured way. For example: If you experience an ongoing pattern of harrassment; if you witness structurally unacceptable behaviour; if somebody keeps "accidentally" using discriminatory language, after being asked to stop.
 
 If you feel comfortable or able, discuss the issues with the involved parties before consulting a conflict mediator. We prefer to constructively resolve disagreements together and work to right the wrong, when it is possible and safe to do so. However, if the problems still persist, those who are responsible for enforcing the code of conduct can help you deal with these kinds of problems. Contact the members listed above. Information will be handled with sensitivity.
+
+The member of the intervention group will be changed based on a rotational system, the specifics of which will be defined in a separate document.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -89,4 +89,4 @@ Some violations need to be considered and consulted upon with more people or in 
 
 If you feel comfortable or able, discuss the issues with the involved parties before consulting a conflict mediator. We prefer to constructively resolve disagreements together and work to right the wrong, when it is possible and safe to do so. However, if the problems still persist, those who are responsible for enforcing the code of conduct can help you deal with these kinds of problems. Contact the members listed above. Information will be handled with sensitivity.
 
-The member of the intervention group will be changed based on a rotational system, the specifics of which will be defined in a separate document.
+The members of the intervention group will be changed based on a rotational system, the specifics of which will be defined in a separate document.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,90 @@
+# European SSB Collective Code of Conduct
+_this document is directly inspired by varia.zone's code of conduct_  https://varia.zone/en/pages/code-of-conduct.html
+
+**The purpose of our Code of Conduct**
+* establish inclusive norms for the community
+* clarify and make explicit unwelcome & unacceptable behaviour
+* outline processes for handling incidents of unwelcome behaviour
+
+### About this Document
+
+The code of conduct is a set of guidelines that help establish shared values as well as inclusive norms and ensure that behaviour that may harm participants is avoided.
+
+This document equally applies to all members of the collective as well as visitors and contributors (including organizers) of events organized by it. The document also applies to users and contributors to online spaces of the collective. When the word "we" is used in this document, it applies to all of the above.
+
+We acknowledge that we come from different backgrounds and all have certain biases and privileges. Therefore, this Code of Conduct cannot account for all the ways that people might feel excluded, unsafe or uncomfortable. We commit to open dialogues, and as such this Code of Conduct is never finished and should change whenever needed. We amend this document over time so it reflects the priorities and sensitivities of the collective as it changes. It is a common responsibility for all of us to enact the behaviour described in this document, and bring it to the physical and digital space we collectively inhabit.
+
+
+### Why a Code of Conduct?
+
+Secure Scuttlebutt, in general, is a complex collective-space. The Scuttleverse is a multi-lingual, multi-cultural, multi-disciplinary spectrum of occasionally overlapping groups of people. 
+
+The European SSB Collective derives its existence, and many of its norms, from this living community and network of Scuttlebutts, as it was at the time of writing this document in 2020.
+
+In the European SSB Collective, we mostly speak English, despite members living all over Europe. We recognize that most members and collaborators are not native speakers. We also recognize that there are multiple ways of speaking and interacting (words, gestures, acts, etc.), depending on cultural backgrounds, educations and practices. As such, we recognize that situations might arise where misunderstandings or conflicts happen. We strive to overcome these misunderstandings through a commitment to open dialogue: we prefer to assume good faith, and ask members, participants or visitors to express their concerns directly to each other when possible. When this is not an option, this Code of Coduct can be consulted for further actions.
+
+The collective is a space for collaboration. It accommodates a whole range of practices. Working together means bridging gaps: between different practices, levels of technical expertise, personal preferences and political or ethical orientations. We strive to create an environment for participants with different ranges of experience, while allowing complex topics to be discussed.
+
+We want the collective to be a space where all members can develop their practices in a collective setting and people feel safe and comfortable to participate, to express themselves, to learn and to work together. The vulnerable nature of collective work means that uncomfortable situations will occur. These situations ask for mutual respect and care. We hope that everyone participating in the collective is respectful, feels able to be vulnerable and exercises care. In the interest of making an inclusive environment, we will not tolerate harassment, exclusion or any other harmful behaviour.
+
+### Expected behaviour
+We expect each other to ...
+
+###### be considerate
+
+of each other, the physical spaces we inhabit during events, seeing each other as individuals as part of contexts.
+
+###### be open and generous
+
+while trying not to make assumptions about others. This can include assumptions about identity, knowledge, experiences or preferred pronouns. Be generous with our time and our abilities, when we are able to. Help others, but ask first. There are many ways to contribute to a collective practice, which may differ from our individual ways.
+
+###### be respectful
+
+of different viewpoints and experiences. Respect physical and emotional boundaries. Be respectful of each others' limited time and energy. Take each other and each other's practices seriously. Acknowledge that this might lead to disagreement. However, disagreement is no excuse for poor manners.
+
+###### be responsible
+
+for the promises we make, meaning that we follow up on our commitments. We take responsibility for the good things we do, but also for the bad ones. We listen to and act upon respectful feedback. We correct ourselves when necessary, keeping in mind that the impact of our words and actions on other people doesn't always match our intent.
+
+###### be dedicated
+
+which means not letting the collective happen to us, but making the collective together. We participate in the collective with self-respect and don't exhaust ourselves. This might mean saying how we feel, setting boundaries, being clear about our expectations. Nobody is expected to be perfect in this community. Asking questions early avoids problems later. Those who are asked should be responsive and helpful.
+
+###### be empathetic,
+
+by actively listening to others and not dominating discussions. We give each other the chance to improve and let each other step up into positions of responsibility. We make room for others. We are aware of each other's feelings, provide support where necessary, and know when to step back. One's idea of caring may differ from how others want to be cared for. We ask to make sure that our actions are wanted.
+
+###### foster an inclusive environment
+
+by trying to create opportunities for others to express views, share skills and make other contributions. Being together is something we actively work on and requires negotiation. We recognize that not everyone has the same opportunities, therefore we must be sensitive to the context we operate in. There are implicit hierarchies that we can challenge, and we should strive to do so. When we organize something (projects, events, etc.), we think about how we can consider degrees of privilege, account for the needs of others, promote an activist stance and support other voices.
+
+### Unacceptable behaviour
+
+###### No structural or personal discrimination,
+
+attitudes or comments promoting or reinforcing the oppression of any groups or people based on gender, gender identity and expression, race, ethnicity, nationality, sexuality, sexual orientation, religion, disability, mental illness, neurodiversity, personal appearance, physical appearance, body size, age, or class. Do not claim “reverse-isms”, for example “reverse racism”.
+
+###### No harrassment,
+
+neither public nor private. Also no deliberate intimidation, stalking, following, harassing photography or recording, disruption of events, aggressive, slanderous, derogatory, or threatening comments online or in person and unwanted physical or electronic contact or sexual attention. No posting or disseminating libel, slander, or other disinformation.
+
+###### No violation of privacy,
+
+namely publishing others’ private information, such as a physical or electronic address, or private messages, without explicit permission. Do not take or publish photos or recordings of others after their request to not do so. Delete recordings if asked.
+
+###### No unwelcome sexual conduct,
+
+including unwanted sexual language, imagery, actions, attention or advances.
+
+###### No destructive behaviour,
+
+or any other conduct which could reasonably be considered inappropriate. This includes (but is not exclusive to) depictions of violence without content warnings, consistently and purposely derailing or disrupting conversations, or other behaviour that persistently disrupts the ability of others to engage in the group or space.
+
+### Intervention procedure
+If you are feeling unsafe, you can contact any of the active members of the intervention group, who are tasked with making sure the code of conduct is respected. These contact people are members of the collective who will do their best to help, or to find the correct assistance if relevant/necessary.
+
+<!-- Add list of people here -->
+
+Some violations need to be considered and consulted upon with more people or in a more measured way. For example: If you experience an ongoing pattern of harrassment; if you witness structurally unacceptable behaviour; if somebody keeps "accidentally" using discriminatory language, after being asked to stop.
+
+If you feel comfortable or able, discuss the issues with the involved parties before consulting a conflict mediator. We prefer to constructively resolve disagreements together and work to right the wrong, when it is possible and safe to do so. However, if the problems still persist, those who are responsible for enforcing the code of conduct can help you deal with these kinds of problems. Contact the members listed above. Information will be handled with sensitivity.


### PR DESCRIPTION
This adds a CoC based off [that by Varia] and has been adapted to our use case by @keks + @cblgh.

There are some open questions around how the team that processes reports of CoC violations works. Specifically, what the impact of rotation is, whether there are some quotas that should always be satisfied, and whether there needs to be some kind of training so that members of the team can properly do the work.

Notes from our call: https://cryptpad.fr/code/#/2/code/edit/IZS3Urvv5t-ObajTfS1G8jjC/

[that by Varia]: https://varia.zone/en/pages/code-of-conduct.html