### PR TITLE
Changed 'Consortium' to 'Collective'

### DIFF
--- a/proposal-membership.md
+++ b/proposal-membership.md
@@ -1,37 +1,37 @@
 # Membership
 
 **Membership Principles**
-1. **Financial stake**: The consortium wishes that each member recurrently contributes financially to the consortium, with the goal of covering costs for collective purposes, such as meetups and others. The contribution amount from each member should be flexible to their financial situation, but we suggest a default contribution amount as a baseline.
-2. **Trust**: The consortium aims to have a high trust level in the group by seeing each other as individuals as part of contexts. This is achieved by maintaining regular communication, distributing care labour and being mindful of hierarchies that may arise.
+1. **Financial stake**: The collective wishes that each member recurrently contributes financially, with the goal of covering costs for common purposes, such as meetups and others. The contribution amount from each member should be flexible to their financial situation, but we suggest a default contribution amount as a baseline.
+2. **Trust**: The collective aims to have a high trust level in the group by seeing each other as individuals as part of contexts. This is achieved by maintaining regular communication, distributing care labour and being mindful of hierarchies that may arise.
 3. **European**: be related to European activities.
-4. **Active participation**: as a member one actively takes part in the practices that have been agreed upon by the consortium.
+4. **Active participation**: as a member one actively takes part in the practices that have been agreed upon by the collective.
 
 **Membership criteria**
 1. Pay a monthly membership fee, flexible for each member, with a suggested baseline of 10€ (which can be paid in advance for up to 12 months). See financial stake.
 2. Be actively vouched for by at least 3 active members: A vouch should be initiated by another active member and can later be removed at any time. (see “Membership Split” for limit cases)
-3. Have physical or legal presence in Europe, or be involved in an active consortium project with at least one member with a physical or legal presence in Europe
+3. Have physical or legal presence in Europe, or be involved in an active collective project with at least one member with a physical or legal presence in Europe
 4. Be a natural person.
 5. If not a member for the last 12 months:
     1. Publicly introduced themselves to the existing members (ex: background, motivation, skills, etc.)
     2. Have made recognized contributions to the larger SSB community (ex: tools, artwork, community gardening, volunteering, etc.)
 6. If a member for the last 12 months: 
     1. Voted in the last annual general assembly
-    2. Have volunteered in the last 12 months on tasks required to keep the consortium running and reported those contributions
+    2. Have volunteered in the last 12 months on tasks required to keep the collective running and reported those contributions
     3. Have attended at least 1 of the last 3 physical gatherings.
 
 If a member fails to maintain their active status by omitting to fulfill some of the criteria above, they become an “Inactive Member” for up to a year, and lose voting rights. An active member will contact them to understand why. The “Inactive Member” can then choose to: (1) fulfill the criteria to become “Active” again, or (2) become a “Past Member”. In the absence of answer, after one year of “Inactive” status, they automatically become “Past Members”. (see “Recognizing Past Members” below)
 
 ### Membership Split
 
-Some members may stop vouching other members such that membership would split into disjoint groups (often two of them). If one of these groups is larger than all others, that group becomes the official consortium. If not, e.g. when it splits into two groups of the same size, the consortium is dissolved and its assets are liquidated and transferred to the Secure Scuttlebutt Consortium Open Collective.
+Some members may stop vouching other members such that membership would split into disjoint groups (often two of them). If one of these groups is larger than all others, that group becomes the official collective. If not, e.g. when it splits into two groups of the same size, the collective is dissolved and its assets are liquidated and transferred to the Secure Scuttlebutt Consortium Open Collective.
 
-The other disjoint groups shall create new consortiums with different names.
+The other disjoint groups shall create new collectives with different names.
 
 ### Recognizing Past Members
 
 Recognition is based on mutual consent:
-  1. Active members are encouraged, but not obliged, to list “Past Members” and a summary of their contributions on the consortium’s public website for posterity.
-  2. “Past Members” have the possibility, but no obligation, to be listed publicly on the consortium website. Their active consent will be sought by active members that want to recognize them, unless the past members are not able to give that consent anymore. In the latter case, the choice of listing or not the “Past Member” is left to the best judgement of the active members.
+  1. Active members are encouraged, but not obliged, to list “Past Members” and a summary of their contributions on the collective’s public website for posterity.
+  2. “Past Members” have the possibility, but no obligation, to be listed publicly on the collective website. Their active consent will be sought by active members that want to recognize them, unless the past members are not able to give that consent anymore. In the latter case, the choice of listing or not the “Past Member” is left to the best judgement of the active members.
 
   ## Modifying the Membership (this document)
   


### PR DESCRIPTION
Changed 'consortium' to 'collective' in the Membership document. No need to all vote on this, I just need an extra pair of eyes to make sure the document still reads well.